### PR TITLE
Fix single quote escapes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -95,8 +95,8 @@ function getOutput(input: string) {
   if (mode === 'Command') {
     const pairs: string[] = []
     components.forEach((key, value) => {
-      const stringValue = key === 'minecraft:custom_name' ? `'${value.getAsString().replace(/'/g, "\\'")}'`
-        : key === 'minecraft:lore' ? `[${(value as NbtList).map(e => `'${e.getAsString().replace(/'/g, "\\'")}'`).join(',')}]`
+      const stringValue = key === 'minecraft:custom_name' ? `'${value.getAsString().replace(/(['\\])/g, "\\$1")}'`
+        : key === 'minecraft:lore' ? `[${(value as NbtList).map(e => `'${e.getAsString().replace(/(['\\])/g, "\\$1")}'`).join(',')}]`
           : value.toString()
       pairs.push(key.replace(/^minecraft:/, '') + '=' + stringValue)
     })

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,8 +95,8 @@ function getOutput(input: string) {
   if (mode === 'Command') {
     const pairs: string[] = []
     components.forEach((key, value) => {
-      const stringValue = key === 'minecraft:custom_name' ? `'${value.getAsString()}'`
-        : key === 'minecraft:lore' ? `[${(value as NbtList).map(e => `'${e.getAsString()}'`).join(',')}]`
+      const stringValue = key === 'minecraft:custom_name' ? `'${value.getAsString().replace(/'/g, "\\'")}'`
+        : key === 'minecraft:lore' ? `[${(value as NbtList).map(e => `'${e.getAsString().replace(/'/g, "\\'")}'`).join(',')}]`
           : value.toString()
       pairs.push(key.replace(/^minecraft:/, '') + '=' + stringValue)
     })


### PR DESCRIPTION
Apparently it loses the old existing escapes on the way. This is specifically for the handling of custom:name and lore